### PR TITLE
Split data management forms into pages and enhance jobs view

### DIFF
--- a/frontend/add_job.php
+++ b/frontend/add_job.php
@@ -1,0 +1,75 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: signin.php');
+    exit;
+}
+if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
+    header('Location: index.php');
+    exit;
+}
+include 'includes/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare("INSERT INTO jobs (job_name, job_number, project_manager) VALUES (?, ?, ?)");
+    $stmt->execute([
+        $_POST['job_name'],
+        $_POST['job_number'],
+        $_POST['project_manager']
+    ]);
+}
+
+$pm_stmt = $pdo->query("SELECT id, first_name, last_name FROM users WHERE role = 'project_manager' ORDER BY first_name");
+$project_managers = $pm_stmt->fetchAll();
+?>
+<?php include 'includes/header.php'; ?>
+    <div class='container-xxl position-relative bg-white d-flex p-0'>
+        <?php include 'includes/spinner.php'; ?>
+        <?php include 'includes/sidebar.php'; ?>
+        <div class='content'>
+            <?php include 'includes/navbar.php'; ?>
+            <div class='container-fluid pt-4 px-4'>
+                <div class='row g-4'>
+                    <div class='col-12'>
+                        <div class='bg-light rounded h-100 p-4'>
+                            <h6 class='mb-4'>Add Job</h6>
+                            <form method='post'>
+                                <div class='mb-3'>
+                                    <label class='form-label'>Job Name</label>
+                                    <input type='text' class='form-control' name='job_name' required>
+                                </div>
+                                <div class='mb-3'>
+                                    <label class='form-label'>Job Number</label>
+                                    <input type='text' class='form-control' name='job_number' required>
+                                </div>
+                                <div class='mb-3'>
+                                    <label class='form-label'>Project Manager</label>
+                                    <select class='form-select' name='project_manager' required>
+                                        <?php foreach ($project_managers as $pm): ?>
+                                            <option value='<?php echo htmlspecialchars($pm['id']); ?>'><?php echo htmlspecialchars($pm['first_name'] . ' ' . $pm['last_name']); ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                                <button type='submit' name='add_job' class='btn btn-primary'>Add Job</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class='container-fluid pt-4 px-4'>
+                <div class='bg-light rounded-top p-4'>
+                    <div class='row'>
+                        <div class='col-12 col-sm-6 text-center text-sm-start'>
+                            &copy; <a href='#'>Your Site Name</a>, All Right Reserved.
+                        </div>
+                        <div class='col-12 col-sm-6 text-center text-sm-end'>
+                            Designed By <a href='https://htmlcodex.com'>HTML Codex</a><br>
+                            Distributed By <a class='border-bottom' href='https://themewagon.com' target='_blank'>ThemeWagon</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <a href='#' class='btn btn-lg btn-primary btn-lg-square back-to-top'><i class='bi bi-arrow-up'></i></a>
+    </div>
+<?php include 'includes/footer.php'; ?>

--- a/frontend/add_pm.php
+++ b/frontend/add_pm.php
@@ -8,6 +8,17 @@ if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
     header('Location: index.php');
     exit;
 }
+include 'includes/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare("INSERT INTO users (email, password, first_name, last_name, role) VALUES (?, ?, ?, ?, 'project_manager')");
+    $stmt->execute([
+        $_POST['email'],
+        password_hash($_POST['password'] ?? 'password', PASSWORD_DEFAULT),
+        $_POST['first_name'],
+        $_POST['last_name']
+    ]);
+}
 ?>
 <?php include 'includes/header.php'; ?>
     <div class='container-xxl position-relative bg-white d-flex p-0'>
@@ -19,11 +30,22 @@ if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
                 <div class='row g-4'>
                     <div class='col-12'>
                         <div class='bg-light rounded h-100 p-4'>
-                            <h6 class='mb-4'>Data Management</h6>
-                            <ul class='list-group'>
-                                <li class='list-group-item'><a href='add_pm.php'>Add Project Manager</a></li>
-                                <li class='list-group-item'><a href='add_job.php'>Add Job</a></li>
-                            </ul>
+                            <h6 class='mb-4'>Add Project Manager</h6>
+                            <form method='post'>
+                                <div class='mb-3'>
+                                    <label class='form-label'>First Name</label>
+                                    <input type='text' class='form-control' name='first_name' required>
+                                </div>
+                                <div class='mb-3'>
+                                    <label class='form-label'>Last Name</label>
+                                    <input type='text' class='form-control' name='last_name' required>
+                                </div>
+                                <div class='mb-3'>
+                                    <label class='form-label'>Email</label>
+                                    <input type='email' class='form-control' name='email' required>
+                                </div>
+                                <button type='submit' name='add_pm' class='btn btn-primary'>Add Project Manager</button>
+                            </form>
                         </div>
                     </div>
                 </div>

--- a/frontend/includes/sidebar.php
+++ b/frontend/includes/sidebar.php
@@ -1,24 +1,26 @@
         <!-- Sidebar Start -->
-        <div class="sidebar pe-4 pb-3">
-            <nav class="navbar bg-light navbar-light">
-                <a href="index.php" class="navbar-brand mx-4 mb-3">
-                    <h3 class="text-primary"><i class="fa fa-hashtag me-2"></i>DASHMIN</h3>
+        <div class='sidebar pe-4 pb-3'>
+            <nav class='navbar bg-light navbar-light'>
+                <a href='index.php' class='navbar-brand mx-4 mb-3'>
+                    <h3 class='text-primary'><i class='fa fa-hashtag me-2'></i>DASHMIN</h3>
                 </a>
-                <div class="d-flex align-items-center ms-4 mb-4">
-                    <div class="position-relative">
-                        <img class="rounded-circle" src="img/user.jpg" alt="" style="width: 40px; height: 40px;">
-                        <div class="bg-success rounded-circle border border-2 border-white position-absolute end-0 bottom-0 p-1"></div>
+                <div class='d-flex align-items-center ms-4 mb-4'>
+                    <div class='position-relative'>
+                        <img class='rounded-circle' src='img/user.jpg' alt='' style='width: 40px; height: 40px;'>
+                        <div class='bg-success rounded-circle border border-2 border-white position-absolute end-0 bottom-0 p-1'></div>
                     </div>
-                    <div class="ms-3">
-                        <h6 class="mb-0"><?php echo htmlspecialchars($_SESSION['first_name'] . ' ' . $_SESSION['last_name']); ?></h6>
+                    <div class='ms-3'>
+                        <h6 class='mb-0'><?php echo htmlspecialchars($_SESSION['first_name'] . ' ' . $_SESSION['last_name']); ?></h6>
                         <span><?php echo htmlspecialchars($_SESSION['role']); ?></span>
                     </div>
                 </div>
-                <div class="navbar-nav w-100">
-                    <a href="index.php" class="nav-item nav-link"><i class="fa fa-tachometer-alt me-2"></i>Dashboard</a>
-                    <a href="jobs.php" class="nav-item nav-link"><i class="fa fa-briefcase me-2"></i>Jobs</a>
+                <div class='navbar-nav w-100'>
+                    <a href='index.php' class='nav-item nav-link'><i class='fa fa-tachometer-alt me-2'></i>Dashboard</a>
+                    <a href='jobs.php' class='nav-item nav-link'><i class='fa fa-briefcase me-2'></i>Jobs</a>
                     <?php if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin'): ?>
-                    <a href="data.php" class="nav-item nav-link"><i class="fa fa-database me-2"></i>Data Management</a>
+                    <a href='data.php' class='nav-item nav-link'><i class='fa fa-database me-2'></i>Data Management</a>
+                    <a href='add_pm.php' class='nav-item nav-link ms-4'><i class='fa fa-user-plus me-2'></i>Add Project Manager</a>
+                    <a href='add_job.php' class='nav-item nav-link ms-4'><i class='fa fa-plus me-2'></i>Add Job</a>
                     <?php endif; ?>
                 </div>
             </nav>

--- a/frontend/jobs.php
+++ b/frontend/jobs.php
@@ -5,32 +5,52 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 include 'includes/db.php';
-$stmt = $pdo->query("SELECT jobs.job_name, jobs.job_number, CONCAT(users.first_name, ' ', users.last_name) AS project_manager FROM jobs LEFT JOIN users ON jobs.project_manager = users.id ORDER BY jobs.job_name");
+$pm_stmt = $pdo->query("SELECT id, first_name, last_name FROM users WHERE role = 'project_manager' ORDER BY first_name");
+$project_managers = $pm_stmt->fetchAll();
+$pm_filter = $_GET['pm'] ?? '';
+if ($pm_filter) {
+    $stmt = $pdo->prepare("SELECT jobs.id, jobs.job_name, jobs.job_number, CONCAT(users.first_name, ' ', users.last_name) AS project_manager FROM jobs LEFT JOIN users ON jobs.project_manager = users.id WHERE jobs.project_manager = ? ORDER BY jobs.job_name");
+    $stmt->execute([$pm_filter]);
+} else {
+    $stmt = $pdo->query("SELECT jobs.id, jobs.job_name, jobs.job_number, CONCAT(users.first_name, ' ', users.last_name) AS project_manager FROM jobs LEFT JOIN users ON jobs.project_manager = users.id ORDER BY jobs.job_name");
+}
 $jobs = $stmt->fetchAll();
 ?>
 <?php include 'includes/header.php'; ?>
-    <div class="container-xxl position-relative bg-white d-flex p-0">
+    <div class='container-xxl position-relative bg-white d-flex p-0'>
         <?php include 'includes/spinner.php'; ?>
         <?php include 'includes/sidebar.php'; ?>
-        <div class="content">
+        <div class='content'>
             <?php include 'includes/navbar.php'; ?>
-            <div class="container-fluid pt-4 px-4">
-                <div class="row g-4">
-                    <div class="col-12">
-                        <div class="bg-light rounded h-100 p-4">
-                            <h6 class="mb-4">Jobs</h6>
-                            <div class="table-responsive">
-                                <table class="table">
+            <div class='container-fluid pt-4 px-4'>
+                <div class='row g-4'>
+                    <div class='col-12'>
+                        <div class='bg-light rounded h-100 p-4'>
+                            <h6 class='mb-4'>Jobs</h6>
+                            <form method='get' class='mb-3'>
+                                <div class='row'>
+                                    <div class='col-md-4'>
+                                        <select name='pm' class='form-select' onchange='this.form.submit()'>
+                                            <option value=''>All Project Managers</option>
+                                            <?php foreach ($project_managers as $pm): ?>
+                                                <option value='<?php echo htmlspecialchars($pm['id']); ?>' <?php if ($pm_filter == $pm['id']) echo 'selected'; ?>><?php echo htmlspecialchars($pm['first_name'] . ' ' . $pm['last_name']); ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+                                </div>
+                            </form>
+                            <div class='table-responsive'>
+                                <table class='table'>
                                     <thead>
                                         <tr>
-                                            <th scope="col">Job Name</th>
-                                            <th scope="col">Job Number</th>
-                                            <th scope="col">Project Manager</th>
+                                            <th scope='col'>Job Name</th>
+                                            <th scope='col'>Job Number</th>
+                                            <th scope='col'>Project Manager</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         <?php foreach ($jobs as $job): ?>
-                                        <tr>
+                                        <tr data-bs-toggle='modal' data-bs-target='#jobModal' data-job='<?php echo htmlspecialchars($job['job_name']); ?>' data-number='<?php echo htmlspecialchars($job['job_number']); ?>' data-pm='<?php echo htmlspecialchars($job['project_manager']); ?>' style='cursor:pointer;'>
                                             <td><?php echo htmlspecialchars($job['job_name']); ?></td>
                                             <td><?php echo htmlspecialchars($job['job_number']); ?></td>
                                             <td><?php echo htmlspecialchars($job['project_manager']); ?></td>
@@ -43,20 +63,48 @@ $jobs = $stmt->fetchAll();
                     </div>
                 </div>
             </div>
-            <div class="container-fluid pt-4 px-4">
-                <div class="bg-light rounded-top p-4">
-                    <div class="row">
-                        <div class="col-12 col-sm-6 text-center text-sm-start">
-                            &copy; <a href="#">Your Site Name</a>, All Right Reserved.
+            <div class='container-fluid pt-4 px-4'>
+                <div class='bg-light rounded-top p-4'>
+                    <div class='row'>
+                        <div class='col-12 col-sm-6 text-center text-sm-start'>
+                            &copy; <a href='#'>Your Site Name</a>, All Right Reserved.
                         </div>
-                        <div class="col-12 col-sm-6 text-center text-sm-end">
-                            Designed By <a href="https://htmlcodex.com">HTML Codex</a><br>
-                            Distributed By <a class="border-bottom" href="https://themewagon.com" target="_blank">ThemeWagon</a>
+                        <div class='col-12 col-sm-6 text-center text-sm-end'>
+                            Designed By <a href='https://htmlcodex.com'>HTML Codex</a><br>
+                            Distributed By <a class='border-bottom' href='https://themewagon.com' target='_blank'>ThemeWagon</a>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        <a href="#" class="btn btn-lg btn-primary btn-lg-square back-to-top"><i class="bi bi-arrow-up"></i></a>
+        <a href='#' class='btn btn-lg btn-primary btn-lg-square back-to-top'><i class='bi bi-arrow-up'></i></a>
     </div>
+    <div class='modal fade' id='jobModal' tabindex='-1' aria-hidden='true'>
+      <div class='modal-dialog'>
+        <div class='modal-content'>
+          <div class='modal-header'>
+            <h5 class='modal-title'>Job Details</h5>
+            <button type='button' class='btn-close' data-bs-dismiss='modal' aria-label='Close'></button>
+          </div>
+          <div class='modal-body'>
+            <p><strong>Project Manager:</strong> <span class='project-manager'></span></p>
+            <p>Work orders will be shown here.</p>
+          </div>
+          <div class='modal-footer'>
+            <button type='button' class='btn btn-secondary' data-bs-dismiss='modal'>Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+    var jobModal = document.getElementById('jobModal');
+    jobModal.addEventListener('show.bs.modal', function (event) {
+        var tr = event.relatedTarget;
+        var jobName = tr.getAttribute('data-job');
+        var jobNumber = tr.getAttribute('data-number');
+        var pm = tr.getAttribute('data-pm');
+        jobModal.querySelector('.modal-title').textContent = jobName + ' (' + jobNumber + ')';
+        jobModal.querySelector('.project-manager').textContent = pm;
+    });
+    </script>
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Separate project manager and job forms into `add_pm.php` and `add_job.php`
- Add Data Management index with links and sidebar subpages
- Enable job table filtering by project manager and add clickable rows opening a detail modal

## Testing
- `php -l data.php`
- `php -l add_pm.php`
- `php -l add_job.php`
- `php -l includes/sidebar.php`
- `php -l jobs.php`


------
https://chatgpt.com/codex/tasks/task_e_68addc3fcee883298b3f2c3cab189084