### PR TITLE
Fix ambiguous column error when fetching work order items

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -15,9 +15,33 @@ CREATE TABLE IF NOT EXISTS jobs (
     project_manager INTEGER REFERENCES users(id)
 );
 
+CREATE TABLE IF NOT EXISTS work_orders (
+    id SERIAL PRIMARY KEY,
+    job_id INTEGER REFERENCES jobs(id) ON DELETE CASCADE,
+    work_order_number INTEGER NOT NULL,
+    material_delivery_date DATE,
+    pull_from_stock BOOLEAN DEFAULT FALSE,
+    delivered BOOLEAN DEFAULT FALSE,
+    UNIQUE (job_id, work_order_number)
+);
+
+CREATE TABLE IF NOT EXISTS work_order_items (
+    id SERIAL PRIMARY KEY,
+    work_order_id INTEGER REFERENCES work_orders(id) ON DELETE CASCADE,
+    item_type VARCHAR(50) NOT NULL,
+    elevation VARCHAR(255),
+    quantity INTEGER,
+    scope VARCHAR(50),
+    comments TEXT,
+    date_required DATE,
+    date_completed DATE,
+    completed_by INTEGER REFERENCES users(id)
+);
+
 INSERT INTO users (email, password, first_name, last_name, role) VALUES
 ('jonk@vosglass.com', '$2y$12$tjzQUJSfUPYl0zv78yK0PeB46dApBH3ox6xIndP4Fc6HgZV2XsODe', 'Jon', 'K', 'admin'),
-('adama@example.com', '$2y$12$MmSdJZgZrqIbXU0cfGWL3OS9IEcGwxfYUIXjPZxCYTiPjsou6Ljce', 'Adam', 'A', 'project_manager')
+('adama@example.com', '$2y$12$MmSdJZgZrqIbXU0cfGWL3OS9IEcGwxfYUIXjPZxCYTiPjsou6Ljce', 'Adam', 'A', 'project_manager'),
+('kevink@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Kevin', 'K', 'fabricator')
 ON CONFLICT (email) DO NOTHING;
 
 INSERT INTO jobs (job_name, job_number, project_manager) VALUES

--- a/frontend/add_work_order.php
+++ b/frontend/add_work_order.php
@@ -1,0 +1,156 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: signin.php');
+    exit;
+}
+include 'includes/db.php';
+$job_id = $_GET['job_id'] ?? $_POST['job_id'] ?? '';
+if (!$job_id) {
+    die('Job required');
+}
+$fabricators = $pdo->query("SELECT id, first_name, last_name FROM users WHERE role = 'fabricator' ORDER BY first_name")->fetchAll();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $delivery = !empty($_POST['material_delivery_date']) ? $_POST['material_delivery_date'] : null;
+    $pull_from_stock = isset($_POST['pull_from_stock']) ? 1 : 0;
+    $delivered = isset($_POST['delivered']) ? 1 : 0;
+    $pdo->beginTransaction();
+    $stmt = $pdo->prepare("SELECT COALESCE(MAX(work_order_number),0)+1 FROM work_orders WHERE job_id = ?");
+    $stmt->execute([$job_id]);
+    $next = $stmt->fetchColumn();
+    $insert = $pdo->prepare("INSERT INTO work_orders (job_id, work_order_number, material_delivery_date, pull_from_stock, delivered) VALUES (?,?,?,?,?) RETURNING id");
+    $insert->execute([$job_id, $next, $delivery, $pull_from_stock, $delivered]);
+    $wo_id = $insert->fetchColumn();
+    if (!empty($_POST['items'])) {
+        $item_sql = "INSERT INTO work_order_items (work_order_id, item_type, elevation, quantity, scope, comments, date_required, date_completed, completed_by) VALUES (?,?,?,?,?,?,?,?,?)";
+        $item_stmt = $pdo->prepare($item_sql);
+        foreach ($_POST['items'] as $item) {
+            $item_stmt->execute([
+                $wo_id,
+                $item['item_type'] ?? '',
+                $item['elevation'] ?? '',
+                $item['quantity'] ?? null,
+                $item['scope'] ?? '',
+                $item['comments'] ?? '',
+                $item['date_required'] ?? null,
+                $item['date_completed'] ?? null,
+                $item['completed_by'] ?? null
+            ]);
+        }
+    }
+    $pdo->commit();
+    header('Location: jobs.php');
+    exit;
+}
+?>
+<?php include 'includes/header.php'; ?>
+    <div class='container-xxl position-relative bg-white d-flex p-0'>
+        <?php include 'includes/spinner.php'; ?>
+        <?php include 'includes/sidebar.php'; ?>
+        <div class='content'>
+            <?php include 'includes/navbar.php'; ?>
+            <div class='container-fluid pt-4 px-4'>
+                <div class='row g-4'>
+                    <div class='col-12'>
+                        <div class='bg-light rounded h-100 p-4'>
+                            <h6 class='mb-4'>Add Work Order</h6>
+                            <form method='post'>
+                                <input type='hidden' name='job_id' value='<?php echo htmlspecialchars($job_id); ?>'>
+                                <div class='mb-3'>
+                                    <label class='form-label'>Material Delivery Date</label>
+                                    <input type='date' name='material_delivery_date' class='form-control'>
+                                    <div class='form-check'>
+                                        <input class='form-check-input' type='checkbox' name='pull_from_stock' id='pull_from_stock'>
+                                        <label class='form-check-label' for='pull_from_stock'>Pull from stock</label>
+                                    </div>
+                                    <div class='form-check'>
+                                        <input class='form-check-input' type='checkbox' name='delivered' id='delivered'>
+                                        <label class='form-check-label' for='delivered'>Delivered</label>
+                                    </div>
+                                </div>
+                                <div id='items-container'>
+                                    <h6>Line Items</h6>
+                                    <div class='row g-2 mb-3 item-row'>
+                                        <div class='col-md-2'>
+                                            <select name='items[0][item_type]' class='form-select'>
+                                                <option value='Curtainwall'>Curtainwall</option>
+                                                <option value='Storefront'>Storefront</option>
+                                                <option value='Doors'>Doors</option>
+                                                <option value='Window wall'>Window wall</option>
+                                            </select>
+                                        </div>
+                                        <div class='col-md-2'><input type='text' name='items[0][elevation]' class='form-control' placeholder='Elevation'></div>
+                                        <div class='col-md-1'><input type='number' name='items[0][quantity]' class='form-control' placeholder='Qty'></div>
+                                        <div class='col-md-2'>
+                                            <select name='items[0][scope]' class='form-select'>
+                                                <option value='assemble'>Assemble</option>
+                                                <option value='kit'>Kit</option>
+                                                <option value='hardware'>Hardware</option>
+                                            </select>
+                                        </div>
+                                        <div class='col-md-2'><input type='text' name='items[0][comments]' class='form-control' placeholder='Comments'></div>
+                                        <div class='col-md-1'><input type='date' name='items[0][date_required]' class='form-control'></div>
+                                        <div class='col-md-1'><input type='date' name='items[0][date_completed]' class='form-control'></div>
+                                        <div class='col-md-1'>
+                                            <select name='items[0][completed_by]' class='form-select'>
+                                                <option value=''>--</option>
+                                                <?php foreach ($fabricators as $fab): ?>
+                                                    <option value='<?php echo htmlspecialchars($fab['id']); ?>'><?php echo htmlspecialchars($fab['first_name'] . ' ' . $fab['last_name']); ?></option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                                <button type='button' class='btn btn-secondary mb-3' id='add-item'>Add Line Item</button>
+                                <div>
+                                    <button type='submit' class='btn btn-primary'>Save</button>
+                                    <a href='jobs.php' class='btn btn-secondary'>Cancel</a>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <a href='#' class='btn btn-lg btn-primary btn-lg-square back-to-top'><i class='bi bi-arrow-up'></i></a>
+    </div>
+    <script>
+    document.getElementById('add-item').addEventListener('click', function() {
+        var container = document.getElementById('items-container');
+        var index = container.querySelectorAll('.item-row').length;
+        var row = document.createElement('div');
+        row.className = 'row g-2 mb-3 item-row';
+        row.innerHTML = `
+            <div class="col-md-2">
+                <select name="items[${index}][item_type]" class="form-select">
+                    <option value="Curtainwall">Curtainwall</option>
+                    <option value="Storefront">Storefront</option>
+                    <option value="Doors">Doors</option>
+                    <option value="Window wall">Window wall</option>
+                </select>
+            </div>
+            <div class="col-md-2"><input type="text" name="items[${index}][elevation]" class="form-control" placeholder="Elevation"></div>
+            <div class="col-md-1"><input type="number" name="items[${index}][quantity]" class="form-control" placeholder="Qty"></div>
+            <div class="col-md-2">
+                <select name="items[${index}][scope]" class="form-select">
+                    <option value="assemble">Assemble</option>
+                    <option value="kit">Kit</option>
+                    <option value="hardware">Hardware</option>
+                </select>
+            </div>
+            <div class="col-md-2"><input type="text" name="items[${index}][comments]" class="form-control" placeholder="Comments"></div>
+            <div class="col-md-1"><input type="date" name="items[${index}][date_required]" class="form-control"></div>
+            <div class="col-md-1"><input type="date" name="items[${index}][date_completed]" class="form-control"></div>
+            <div class="col-md-1">
+                <select name="items[${index}][completed_by]" class="form-select">
+                    <option value="">--</option>
+                    <?php foreach ($fabricators as $fab): ?>
+                        <option value="<?php echo htmlspecialchars($fab['id']); ?>"><?php echo htmlspecialchars($fab['first_name'] . ' ' . $fab['last_name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>`;
+        container.appendChild(row);
+    });
+    </script>
+<?php include 'includes/footer.php'; ?>
+

--- a/frontend/get_work_orders.php
+++ b/frontend/get_work_orders.php
@@ -1,0 +1,52 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(403);
+    exit;
+}
+include 'includes/db.php';
+$job_id = $_GET['job_id'] ?? '';
+if (!$job_id) {
+    echo 'No job selected.';
+    exit;
+}
+$wo_stmt = $pdo->prepare("SELECT id, work_order_number, material_delivery_date, pull_from_stock, delivered FROM work_orders WHERE job_id = ? ORDER BY work_order_number");
+$wo_stmt->execute([$job_id]);
+$work_orders = $wo_stmt->fetchAll();
+foreach ($work_orders as $wo) {
+    echo "<div class='mb-3'>";
+    echo "<h6>Work Order " . htmlspecialchars($wo['work_order_number']) . "</h6>";
+    if ($wo['pull_from_stock']) {
+        echo '<p>Pull from stock</p>';
+    } elseif ($wo['delivered']) {
+        echo '<p>Delivered</p>';
+    } elseif ($wo['material_delivery_date']) {
+        echo '<p>Material Delivery: ' . htmlspecialchars($wo['material_delivery_date']) . '</p>';
+    }
+    // Explicitly order by the work_order_items table to avoid ambiguous column errors
+    $item_stmt = $pdo->prepare("SELECT item_type, elevation, quantity, scope, comments, date_required, date_completed, CONCAT(u.first_name, ' ', u.last_name) AS completed_by_name FROM work_order_items LEFT JOIN users u ON work_order_items.completed_by = u.id WHERE work_order_id = ? ORDER BY work_order_items.id");
+    $item_stmt->execute([$wo['id']]);
+    $items = $item_stmt->fetchAll();
+    if ($items) {
+        echo "<table class='table'><thead><tr><th>Type</th><th>Elevation</th><th>Qty</th><th>Scope</th><th>Comments</th><th>Date Required</th><th>Date Completed</th><th>Completed By</th></tr></thead><tbody>";
+        foreach ($items as $it) {
+            echo '<tr>';
+            echo '<td>' . htmlspecialchars($it['item_type']) . '</td>';
+            echo '<td>' . htmlspecialchars($it['elevation']) . '</td>';
+            echo '<td>' . htmlspecialchars($it['quantity']) . '</td>';
+            echo '<td>' . htmlspecialchars($it['scope']) . '</td>';
+            echo '<td>' . htmlspecialchars($it['comments']) . '</td>';
+            echo '<td>' . htmlspecialchars($it['date_required']) . '</td>';
+            echo '<td>' . htmlspecialchars($it['date_completed']) . '</td>';
+            echo '<td>' . htmlspecialchars($it['completed_by_name']) . '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+    } else {
+        echo '<p>No line items.</p>';
+    }
+    echo '</div>';
+}
+echo "<a href='add_work_order.php?job_id=" . urlencode($job_id) . "' class='btn btn-primary'>Add Work Order</a>";
+?>
+

--- a/frontend/jobs.php
+++ b/frontend/jobs.php
@@ -8,11 +8,18 @@ include 'includes/db.php';
 $pm_stmt = $pdo->query("SELECT id, first_name, last_name FROM users WHERE role = 'project_manager' ORDER BY first_name");
 $project_managers = $pm_stmt->fetchAll();
 $pm_filter = $_GET['pm'] ?? '';
+$sort = $_GET['sort'] ?? 'job_name';
+$order = $_GET['order'] ?? 'asc';
+$allowed_sorts = ['job_name', 'job_number', 'project_manager'];
+if (!in_array($sort, $allowed_sorts)) {
+    $sort = 'job_name';
+}
+$order = strtolower($order) === 'desc' ? 'desc' : 'asc';
 if ($pm_filter) {
-    $stmt = $pdo->prepare("SELECT jobs.id, jobs.job_name, jobs.job_number, CONCAT(users.first_name, ' ', users.last_name) AS project_manager FROM jobs LEFT JOIN users ON jobs.project_manager = users.id WHERE jobs.project_manager = ? ORDER BY jobs.job_name");
+    $stmt = $pdo->prepare("SELECT jobs.id, jobs.job_name, jobs.job_number, CONCAT(users.first_name, ' ', users.last_name) AS project_manager FROM jobs LEFT JOIN users ON jobs.project_manager = users.id WHERE jobs.project_manager = ? ORDER BY $sort $order");
     $stmt->execute([$pm_filter]);
 } else {
-    $stmt = $pdo->query("SELECT jobs.id, jobs.job_name, jobs.job_number, CONCAT(users.first_name, ' ', users.last_name) AS project_manager FROM jobs LEFT JOIN users ON jobs.project_manager = users.id ORDER BY jobs.job_name");
+    $stmt = $pdo->query("SELECT jobs.id, jobs.job_name, jobs.job_number, CONCAT(users.first_name, ' ', users.last_name) AS project_manager FROM jobs LEFT JOIN users ON jobs.project_manager = users.id ORDER BY $sort $order");
 }
 $jobs = $stmt->fetchAll();
 ?>
@@ -43,14 +50,23 @@ $jobs = $stmt->fetchAll();
                                 <table class='table'>
                                     <thead>
                                         <tr>
-                                            <th scope='col'>Job Name</th>
-                                            <th scope='col'>Job Number</th>
-                                            <th scope='col'>Project Manager</th>
+                                            <?php
+                                            $nameOrder = ($sort === 'job_name' && $order === 'asc') ? 'desc' : 'asc';
+                                            $numberOrder = ($sort === 'job_number' && $order === 'asc') ? 'desc' : 'asc';
+                                            $pmOrder = ($sort === 'project_manager' && $order === 'asc') ? 'desc' : 'asc';
+                                            $pmParam = $pm_filter ? '&pm=' . urlencode($pm_filter) : '';
+                                            $nameLink = "?sort=job_name&order={$nameOrder}{$pmParam}";
+                                            $numberLink = "?sort=job_number&order={$numberOrder}{$pmParam}";
+                                            $pmLink = "?sort=project_manager&order={$pmOrder}{$pmParam}";
+                                            ?>
+                                            <th scope='col'><a href='<?php echo $nameLink; ?>'>Job Name</a></th>
+                                            <th scope='col'><a href='<?php echo $numberLink; ?>'>Job Number</a></th>
+                                            <th scope='col'><a href='<?php echo $pmLink; ?>'>Project Manager</a></th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         <?php foreach ($jobs as $job): ?>
-                                        <tr data-bs-toggle='modal' data-bs-target='#jobModal' data-job='<?php echo htmlspecialchars($job['job_name']); ?>' data-number='<?php echo htmlspecialchars($job['job_number']); ?>' data-pm='<?php echo htmlspecialchars($job['project_manager']); ?>' style='cursor:pointer;'>
+                                        <tr data-bs-toggle='modal' data-bs-target='#jobModal' data-id='<?php echo htmlspecialchars($job['id']); ?>' data-job='<?php echo htmlspecialchars($job['job_name']); ?>' data-number='<?php echo htmlspecialchars($job['job_number']); ?>' data-pm='<?php echo htmlspecialchars($job['project_manager']); ?>' style='cursor:pointer;'>
                                             <td><?php echo htmlspecialchars($job['job_name']); ?></td>
                                             <td><?php echo htmlspecialchars($job['job_number']); ?></td>
                                             <td><?php echo htmlspecialchars($job['project_manager']); ?></td>
@@ -88,7 +104,7 @@ $jobs = $stmt->fetchAll();
           </div>
           <div class='modal-body'>
             <p><strong>Project Manager:</strong> <span class='project-manager'></span></p>
-            <p>Work orders will be shown here.</p>
+            <div id='work-orders'></div>
           </div>
           <div class='modal-footer'>
             <button type='button' class='btn btn-secondary' data-bs-dismiss='modal'>Close</button>
@@ -100,11 +116,17 @@ $jobs = $stmt->fetchAll();
     var jobModal = document.getElementById('jobModal');
     jobModal.addEventListener('show.bs.modal', function (event) {
         var tr = event.relatedTarget;
+        var jobId = tr.getAttribute('data-id');
         var jobName = tr.getAttribute('data-job');
         var jobNumber = tr.getAttribute('data-number');
         var pm = tr.getAttribute('data-pm');
         jobModal.querySelector('.modal-title').textContent = jobName + ' (' + jobNumber + ')';
         jobModal.querySelector('.project-manager').textContent = pm;
+        fetch('get_work_orders.php?job_id=' + encodeURIComponent(jobId))
+            .then(function(response) { return response.text(); })
+            .then(function(html) {
+                jobModal.querySelector('#work-orders').innerHTML = html;
+            });
     });
     </script>
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- ensure work order items query orders by work_order_items.id to avoid ambiguous column name

## Testing
- `php -l frontend/get_work_orders.php`


------
https://chatgpt.com/codex/tasks/task_e_68ade11382948329823fdd9dc7c9d887