### PR TITLE
Fix missing completed_by param in work order items

### DIFF
--- a/frontend/add_work_order.php
+++ b/frontend/add_work_order.php
@@ -33,13 +33,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $item_stmt->execute([
                 $wo_id,
                 $item['item_type'] ?? '',
-                $item['elevation'] ?? '',         
-                $item['quantity'] ?? null,
+                $item['elevation'] ?? '',
+                $quantity,
                 $item['scope'] ?? '',
                 $item['comments'] ?? '',
-                $item['date_required'] ?? null,
-                $item['date_completed'] ?? null,
-
+                $date_required,
+                $date_completed,
+                $completed_by,
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- ensure work order item insert uses all 9 placeholders including completed_by

## Testing
- `php -l frontend/add_work_order.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae5ffef7f88329bf8a78db658b517a