### PR TITLE
Add work order editing, deletion, and draft workflow

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -22,8 +22,11 @@ CREATE TABLE IF NOT EXISTS work_orders (
     material_delivery_date DATE,
     pull_from_stock BOOLEAN DEFAULT FALSE,
     delivered BOOLEAN DEFAULT FALSE,
+    status VARCHAR(20) NOT NULL DEFAULT 'draft',
     UNIQUE (job_id, work_order_number)
 );
+
+ALTER TABLE work_orders ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'draft';
 
 CREATE TABLE IF NOT EXISTS work_order_items (
     id SERIAL PRIMARY KEY,
@@ -41,7 +44,9 @@ CREATE TABLE IF NOT EXISTS work_order_items (
 INSERT INTO users (email, password, first_name, last_name, role) VALUES
 ('jonk@vosglass.com', '$2y$12$tjzQUJSfUPYl0zv78yK0PeB46dApBH3ox6xIndP4Fc6HgZV2XsODe', 'Jon', 'K', 'admin'),
 ('adama@example.com', '$2y$12$MmSdJZgZrqIbXU0cfGWL3OS9IEcGwxfYUIXjPZxCYTiPjsou6Ljce', 'Adam', 'A', 'project_manager'),
-('kevink@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Kevin', 'K', 'fabricator')
+('kevink@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Kevin', 'K', 'fabricator'),
+('jasonj@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Jason', 'J', 'fab_leader'),
+('peted@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Pete', 'D', 'superintendent')
 ON CONFLICT (email) DO NOTHING;
 
 INSERT INTO jobs (job_name, job_number, project_manager) VALUES

--- a/frontend/delete_work_order.php
+++ b/frontend/delete_work_order.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: signin.php');
+    exit;
+}
+include 'includes/db.php';
+
+$id = $_GET['id'] ?? '';
+if ($id) {
+    $stmt = $pdo->prepare("DELETE FROM work_orders WHERE id = ?");
+    $stmt->execute([$id]);
+}
+
+header('Location: jobs.php');
+exit;
+?>
+

--- a/frontend/get_work_orders.php
+++ b/frontend/get_work_orders.php
@@ -10,12 +10,13 @@ if (!$job_id) {
     echo 'No job selected.';
     exit;
 }
-$wo_stmt = $pdo->prepare("SELECT id, work_order_number, material_delivery_date, pull_from_stock, delivered FROM work_orders WHERE job_id = ? ORDER BY work_order_number");
+$wo_stmt = $pdo->prepare("SELECT id, work_order_number, material_delivery_date, pull_from_stock, delivered, status FROM work_orders WHERE job_id = ? ORDER BY work_order_number");
 $wo_stmt->execute([$job_id]);
 $work_orders = $wo_stmt->fetchAll();
 foreach ($work_orders as $wo) {
     echo "<div class='mb-3'>";
     echo "<h6>Work Order " . htmlspecialchars($wo['work_order_number'] ?? '') . "</h6>";
+    echo '<p>Status: ' . htmlspecialchars($wo['status'] ?? '') . '</p>';
     if ($wo['pull_from_stock']) {
         echo '<p>Pull from stock</p>';
     } elseif ($wo['delivered']) {
@@ -45,6 +46,8 @@ foreach ($work_orders as $wo) {
     } else {
         echo '<p>No line items.</p>';
     }
+    echo "<a href='edit_work_order.php?id=" . urlencode($wo['id']) . "' class='btn btn-sm btn-secondary me-2'>Edit</a>";
+    echo "<a href='delete_work_order.php?id=" . urlencode($wo['id']) . "' class='btn btn-sm btn-danger' onclick=\"return confirm('Delete work order?');\">Delete</a>";
     echo '</div>';
 }
 echo "<a href='add_work_order.php?job_id=" . urlencode($job_id) . "' class='btn btn-primary'>Add Work Order</a>";


### PR DESCRIPTION
## Summary
- allow work orders to be saved as drafts or submitted
- show status and provide edit/delete actions on work orders
- scaffold workflow with new roles and status field in schema

## Testing
- `php -l frontend/add_work_order.php`
- `php -l frontend/get_work_orders.php`
- `php -l frontend/edit_work_order.php`
- `php -l frontend/delete_work_order.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae63ad6cc88329a88278b30cb81f07