### PR TITLE
Add categories and quantities to door part requirements

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -49,13 +49,15 @@ CREATE TABLE IF NOT EXISTS door_parts (
     lx NUMERIC,
     ly NUMERIC,
     lz NUMERIC,
-    function VARCHAR(50) NOT NULL
+    function VARCHAR(50) NOT NULL,
+    category VARCHAR(50) NOT NULL DEFAULT 'door'
 );
 
 CREATE TABLE IF NOT EXISTS door_part_requirements (
     id SERIAL PRIMARY KEY,
     part_id INTEGER REFERENCES door_parts(id) ON DELETE CASCADE,
-    required_part_id INTEGER REFERENCES door_parts(id) ON DELETE CASCADE
+    required_part_id INTEGER REFERENCES door_parts(id) ON DELETE CASCADE,
+    quantity INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE TABLE IF NOT EXISTS door_configurations (


### PR DESCRIPTION
## Summary
- Allow specifying part category when adding door parts
- Replace multi-select requirements with dropdowns that include quantity
- Store requirement quantity in database schema

## Testing
- `php -l add_door_part.php`

------
https://chatgpt.com/codex/tasks/task_e_68ae686a3278832993a33243aa791b60