### PR TITLE
Add dynamic part creation form with category-specific fields

### DIFF
--- a/frontend/add_part.php
+++ b/frontend/add_part.php
@@ -1,0 +1,122 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: signin.php');
+    exit;
+}
+if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
+    header('Location: index.php');
+    exit;
+}
+include 'includes/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $category = $_POST['category'];
+    $lx = $ly = $lz = null;
+    $function = null;
+
+    switch ($category) {
+        case 'frame':
+            $lx = $_POST['lx'] !== '' ? $_POST['lx'] : null;
+            $ly = $_POST['ly'] !== '' ? $_POST['ly'] : null;
+            $lz = $_POST['lz'] !== '' ? $_POST['lz'] : null;
+            $function = 'frame';
+            break;
+        case 'fastener':
+            $lx = $_POST['length'] !== '' ? $_POST['length'] : null;
+            $ly = $_POST['diameter'] !== '' ? $_POST['diameter'] : null;
+            $function = 'fastener';
+            break;
+        case 'door':
+            $lx = $_POST['lx'] !== '' ? $_POST['lx'] : null;
+            $ly = $_POST['ly'] !== '' ? $_POST['ly'] : null;
+            $lz = $_POST['lz'] !== '' ? $_POST['lz'] : null;
+            $function = $_POST['function'] ?? 'door';
+            break;
+        case 'accessory':
+            $function = 'accessory';
+            break;
+    }
+
+    $stmt = $pdo->prepare('INSERT INTO door_parts (manufacturer, system, part_number, lx, ly, lz, function, category) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+    $stmt->execute([
+        $_POST['manufacturer'],
+        $_POST['system'],
+        $_POST['part_number'],
+        $lx,
+        $ly,
+        $lz,
+        $function,
+        $category
+    ]);
+}
+?>
+<?php include 'includes/header.php'; ?>
+<div class='container-xxl position-relative bg-white d-flex p-0'>
+    <?php include 'includes/spinner.php'; ?>
+    <?php include 'includes/sidebar.php'; ?>
+    <div class='content'>
+        <?php include 'includes/navbar.php'; ?>
+        <div class='container-fluid pt-4 px-4'>
+            <div class='row g-4'>
+                <div class='col-12'>
+                    <div class='bg-light rounded h-100 p-4'>
+                        <h6 class='mb-4'>Add Part</h6>
+                        <form method='post'>
+                            <div class='mb-3'>
+                                <label class='form-label'>Manufacturer</label>
+                                <input type='text' class='form-control' name='manufacturer' required>
+                            </div>
+                            <div class='mb-3'>
+                                <label class='form-label'>System</label>
+                                <input type='text' class='form-control' name='system' required>
+                            </div>
+                            <div class='mb-3'>
+                                <label class='form-label'>Part Number</label>
+                                <input type='text' class='form-control' name='part_number' required>
+                            </div>
+                            <div class='mb-3'>
+                                <label class='form-label'>Category</label>
+                                <select class='form-select' name='category' id='category' required>
+                                    <option value='frame'>Frame Part</option>
+                                    <option value='fastener'>Fastener</option>
+                                    <option value='accessory'>Accessory</option>
+                                    <option value='door'>Door Part</option>
+                                </select>
+                            </div>
+                            <div id='categoryFields'></div>
+                            <button type='submit' class='btn btn-primary'>Add Part</button>
+                        </form>
+                        <script>
+                            function loadCategoryFields() {
+                                var category = document.getElementById('category').value;
+                                fetch('includes/parts/' + category + '_fields.php')
+                                    .then(response => response.text())
+                                    .then(html => {
+                                        document.getElementById('categoryFields').innerHTML = html;
+                                    });
+                            }
+                            document.getElementById('category').addEventListener('change', loadCategoryFields);
+                            loadCategoryFields();
+                        </script>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class='container-fluid pt-4 px-4'>
+            <div class='bg-light rounded-top p-4'>
+                <div class='row'>
+                    <div class='col-12 col-sm-6 text-center text-sm-start'>
+                        &copy; <a href='#'>Your Site Name</a>, All Right Reserved.
+                    </div>
+                    <div class='col-12 col-sm-6 text-center text-sm-end'>
+                        Designed By <a href='https://htmlcodex.com'>HTML Codex</a><br>
+                        Distributed By <a class='border-bottom' href='https://themewagon.com' target='_blank'>ThemeWagon</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <a href='#' class='btn btn-lg btn-primary btn-lg-square back-to-top'><i class='bi bi-arrow-up'></i></a>
+</div>
+<?php include 'includes/footer.php'; ?>

--- a/frontend/includes/parts/accessory_fields.php
+++ b/frontend/includes/parts/accessory_fields.php
@@ -1,0 +1,4 @@
+<div class='mb-3'>
+    <label class='form-label'>Description</label>
+    <input type='text' class='form-control' name='description'>
+</div>

--- a/frontend/includes/parts/door_fields.php
+++ b/frontend/includes/parts/door_fields.php
@@ -1,0 +1,21 @@
+<div class='mb-3'>
+    <label class='form-label'>LX</label>
+    <input type='number' step='any' class='form-control' name='lx'>
+</div>
+<div class='mb-3'>
+    <label class='form-label'>LY</label>
+    <input type='number' step='any' class='form-control' name='ly'>
+</div>
+<div class='mb-3'>
+    <label class='form-label'>LZ</label>
+    <input type='number' step='any' class='form-control' name='lz'>
+</div>
+<div class='mb-3'>
+    <label class='form-label'>Function</label>
+    <select class='form-select' name='function' required>
+        <option value='hinge_rail'>Hinge Rail</option>
+        <option value='lock_rail'>Lock Rail</option>
+        <option value='top_rail'>Top Rail</option>
+        <option value='bottom_rail'>Bottom Rail</option>
+    </select>
+</div>

--- a/frontend/includes/parts/fastener_fields.php
+++ b/frontend/includes/parts/fastener_fields.php
@@ -1,0 +1,8 @@
+<div class='mb-3'>
+    <label class='form-label'>Length</label>
+    <input type='number' step='any' class='form-control' name='length'>
+</div>
+<div class='mb-3'>
+    <label class='form-label'>Diameter</label>
+    <input type='number' step='any' class='form-control' name='diameter'>
+</div>

--- a/frontend/includes/parts/frame_fields.php
+++ b/frontend/includes/parts/frame_fields.php
@@ -1,0 +1,12 @@
+<div class='mb-3'>
+    <label class='form-label'>LX</label>
+    <input type='number' step='any' class='form-control' name='lx'>
+</div>
+<div class='mb-3'>
+    <label class='form-label'>LY</label>
+    <input type='number' step='any' class='form-control' name='ly'>
+</div>
+<div class='mb-3'>
+    <label class='form-label'>LZ</label>
+    <input type='number' step='any' class='form-control' name='lz'>
+</div>


### PR DESCRIPTION
## Summary
- Introduce `add_part.php` with common part attributes and dynamic category field loading.
- Implement server logic to map category-specific inputs and insert into `door_parts`.
- Add partials for door, frame, fastener and accessory categories under `frontend/includes/parts/`.

## Testing
- `php -l frontend/add_part.php`
- `php -l frontend/includes/parts/frame_fields.php`
- `php -l frontend/includes/parts/fastener_fields.php`
- `php -l frontend/includes/parts/door_fields.php`
- `php -l frontend/includes/parts/accessory_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae6dbad0988329bd15176723b5423e