### PR TITLE
Enable multiple functions per door part

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -78,6 +78,12 @@ CREATE TABLE IF NOT EXISTS door_parts (
     category VARCHAR(50) NOT NULL DEFAULT 'door'
 );
 
+CREATE TABLE IF NOT EXISTS door_part_functions (
+    part_id INTEGER REFERENCES door_parts(id) ON DELETE CASCADE,
+    function VARCHAR(50) NOT NULL,
+    PRIMARY KEY (part_id, function)
+);
+
 CREATE TABLE IF NOT EXISTS door_part_requirements (
     id SERIAL PRIMARY KEY,
     part_id INTEGER REFERENCES door_parts(id) ON DELETE CASCADE,

--- a/frontend/add_part.php
+++ b/frontend/add_part.php
@@ -18,6 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $category = $_POST['category'];
     $lx = $ly = $lz = null;
     $function = null;
+    $functions = [];
 
     switch ($category) {
         case 'frame':
@@ -35,7 +36,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $lx = $_POST['lx'] !== '' ? $_POST['lx'] : null;
             $ly = $_POST['ly'] !== '' ? $_POST['ly'] : null;
             $lz = $_POST['lz'] !== '' ? $_POST['lz'] : null;
-            $function = $_POST['function'] ?? 'door';
+            $functions = isset($_POST['functions']) ? $_POST['functions'] : [];
+            $function = $functions[0] ?? 'door';
             break;
         case 'accessory':
             $function = 'accessory';
@@ -55,6 +57,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     ]);
 
     $part_id = $pdo->lastInsertId();
+    if (!empty($functions)) {
+        $func_stmt = $pdo->prepare('INSERT INTO door_part_functions (part_id, function) VALUES (?, ?)');
+        foreach ($functions as $func) {
+            $func_stmt->execute([$part_id, $func]);
+        }
+    }
     if (!empty($_POST['required_parts'])) {
         $req_stmt = $pdo->prepare('INSERT INTO door_part_requirements (part_id, required_part_id, quantity) VALUES (?, ?, ?)');
         foreach ($_POST['required_parts'] as $index => $req) {

--- a/frontend/door_configurator.php
+++ b/frontend/door_configurator.php
@@ -17,10 +17,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     ]);
 }
 
-$hinge_parts = $pdo->query("SELECT id, manufacturer, system, part_number FROM door_parts WHERE function = 'hinge_rail' ORDER BY manufacturer, system, part_number")->fetchAll();
-$lock_parts = $pdo->query("SELECT id, manufacturer, system, part_number FROM door_parts WHERE function = 'lock_rail' ORDER BY manufacturer, system, part_number")->fetchAll();
-$top_parts = $pdo->query("SELECT id, manufacturer, system, part_number FROM door_parts WHERE function = 'top_rail' ORDER BY manufacturer, system, part_number")->fetchAll();
-$bottom_parts = $pdo->query("SELECT id, manufacturer, system, part_number FROM door_parts WHERE function = 'bottom_rail' ORDER BY manufacturer, system, part_number")->fetchAll();
+$hinge_parts = $pdo->query("SELECT DISTINCT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'hinge_rail' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
+$lock_parts = $pdo->query("SELECT DISTINCT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'lock_rail' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
+$top_parts = $pdo->query("SELECT DISTINCT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'top_rail' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
+$bottom_parts = $pdo->query("SELECT DISTINCT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'bottom_rail' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 ?>
 <?php include 'includes/header.php'; ?>
     <div class='container-xxl position-relative bg-white d-flex p-0'>

--- a/frontend/includes/parts/door_fields.php
+++ b/frontend/includes/parts/door_fields.php
@@ -12,7 +12,7 @@
 </div>
 <div class='mb-3'>
     <label class='form-label'>Function</label>
-    <select class='form-select' name='function' required>
+    <select class='form-select' name='functions[]' multiple required>
         <option value='hinge_rail'>Hinge Rail</option>
         <option value='lock_rail'>Lock Rail</option>
         <option value='top_rail'>Top Rail</option>


### PR DESCRIPTION
## Summary
- allow selecting multiple uses on door part forms
- track door part uses in new `door_part_functions` table
- show parts with matching uses in door configurator

## Testing
- `php -l frontend/add_door_part.php`
- `php -l frontend/add_part.php`
- `php -l frontend/door_configurator.php`
- `php -l frontend/includes/parts/door_fields.php`

------
https://chatgpt.com/codex/tasks/task_e_68afa4ef282083298924d62949f36ece