### PR TITLE
Keep role selector for dev users

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS users (
 ALTER TABLE users ADD COLUMN IF NOT EXISTS first_name VARCHAR(255);
 ALTER TABLE users ADD COLUMN IF NOT EXISTS last_name VARCHAR(255);
 ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(50) NOT NULL DEFAULT 'user';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_dev BOOLEAN NOT NULL DEFAULT FALSE;
 
 CREATE TABLE IF NOT EXISTS jobs (
     id SERIAL PRIMARY KEY,
@@ -122,12 +123,12 @@ ALTER TABLE door_configurations ADD COLUMN IF NOT EXISTS lock_rail_2_id INTEGER 
 ALTER TABLE door_configurations ADD COLUMN IF NOT EXISTS top_rail_2_id INTEGER REFERENCES door_parts(id);
 ALTER TABLE door_configurations ADD COLUMN IF NOT EXISTS bottom_rail_2_id INTEGER REFERENCES door_parts(id);
 
-INSERT INTO users (email, password, first_name, last_name, role) VALUES
-('jonk@vosglass.com', '$2y$12$tjzQUJSfUPYl0zv78yK0PeB46dApBH3ox6xIndP4Fc6HgZV2XsODe', 'Jon', 'K', 'admin'),
-('adama@example.com', '$2y$12$MmSdJZgZrqIbXU0cfGWL3OS9IEcGwxfYUIXjPZxCYTiPjsou6Ljce', 'Adam', 'A', 'project_manager'),
-('kevink@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Kevin', 'K', 'fabricator'),
-('jasonj@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Jason', 'J', 'fab_leader'),
-('peted@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Pete', 'D', 'superintendent')
+INSERT INTO users (email, password, first_name, last_name, role, is_dev) VALUES
+('jonk@vosglass.com', '$2y$12$tjzQUJSfUPYl0zv78yK0PeB46dApBH3ox6xIndP4Fc6HgZV2XsODe', 'Jon', 'K', 'admin', TRUE),
+('adama@example.com', '$2y$12$MmSdJZgZrqIbXU0cfGWL3OS9IEcGwxfYUIXjPZxCYTiPjsou6Ljce', 'Adam', 'A', 'project_manager', FALSE),
+('kevink@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Kevin', 'K', 'fabricator', FALSE),
+('jasonj@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Jason', 'J', 'fab_leader', FALSE),
+('peted@example.com', '$2y$10$w1WAnbcWcCYwiVdc0GqORu0Yv7FpC18m0tHbdD.N14Q6gttYVOlBm', 'Pete', 'D', 'superintendent', FALSE)
 ON CONFLICT (email) DO NOTHING;
 
 INSERT INTO jobs (job_name, job_number, project_manager) VALUES

--- a/frontend/includes/navbar.php
+++ b/frontend/includes/navbar.php
@@ -10,7 +10,7 @@
                     <input class="form-control border-0" type="search" placeholder="Search">
                 </form>
                 <div class="navbar-nav align-items-center ms-auto">
-                    <?php if ($_SESSION['role'] === 'admin'): ?>
+                    <?php if (($_SESSION['role'] ?? '') === 'admin' || (!empty($_SESSION['is_dev']) && $_SESSION['is_dev'])): ?>
                     <form method="post" action="switch_role.php" class="me-3">
                         <select name="role" class="form-select form-select-sm" onchange="this.form.submit()">
                             <option value="admin" <?php if ($_SESSION['role']==='admin') echo 'selected';?>>Admin</option>

--- a/frontend/signin.php
+++ b/frontend/signin.php
@@ -5,7 +5,7 @@ $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = $_POST['email'] ?? '';
     $password = $_POST['password'] ?? '';
-    $stmt = $pdo->prepare('SELECT id, password, first_name, last_name, role FROM users WHERE email = ?');
+    $stmt = $pdo->prepare('SELECT id, password, first_name, last_name, role, is_dev FROM users WHERE email = ?');
     $stmt->execute([$email]);
     $user = $stmt->fetch();
     if ($user && password_verify($password, $user['password'])) {
@@ -13,6 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['first_name'] = $user['first_name'];
         $_SESSION['last_name'] = $user['last_name'];
         $_SESSION['role'] = $user['role'];
+        $_SESSION['is_dev'] = $user['is_dev'];
         header('Location: index.php');
         exit;
     } else {

--- a/frontend/switch_role.php
+++ b/frontend/switch_role.php
@@ -4,7 +4,7 @@ if (!isset($_SESSION['user_id'])) {
     header('Location: signin.php');
     exit;
 }
-if ($_SESSION['role'] !== 'admin') {
+if (($_SESSION['role'] ?? '') !== 'admin' && empty($_SESSION['is_dev'])) {
     header('Location: index.php');
     exit;
 }


### PR DESCRIPTION
## Summary
- Add `is_dev` flag to users table and seed Jon as dev admin
- Persist dev status in session and show role switcher to devs
- Allow devs to access role switch endpoint

## Testing
- `php -l frontend/signin.php`
- `php -l frontend/includes/navbar.php`
- `php -l frontend/switch_role.php`

------
https://chatgpt.com/codex/tasks/task_e_68afbda9af708329aeb8ee0e9a59b6ec