### PR TITLE
Keep role selector visible after switching roles

### DIFF
--- a/frontend/includes/navbar.php
+++ b/frontend/includes/navbar.php
@@ -10,7 +10,7 @@
                     <input class="form-control border-0" type="search" placeholder="Search">
                 </form>
                 <div class="navbar-nav align-items-center ms-auto">
-                    <?php if (($_SESSION['role'] ?? '') === 'admin' || (!empty($_SESSION['is_dev']) && $_SESSION['is_dev'])): ?>
+                    <?php if (($_SESSION['original_role'] ?? '') === 'admin' || (!empty($_SESSION['is_dev']) && $_SESSION['is_dev'])): ?>
                     <form method="post" action="switch_role.php" class="me-3">
                         <select name="role" class="form-select form-select-sm" onchange="this.form.submit()">
                             <option value="admin" <?php if ($_SESSION['role']==='admin') echo 'selected';?>>Admin</option>

--- a/frontend/signin.php
+++ b/frontend/signin.php
@@ -13,6 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $_SESSION['first_name'] = $user['first_name'];
         $_SESSION['last_name'] = $user['last_name'];
         $_SESSION['role'] = $user['role'];
+        $_SESSION['original_role'] = $user['role'];
         $_SESSION['is_dev'] = $user['is_dev'];
         header('Location: index.php');
         exit;

--- a/frontend/switch_role.php
+++ b/frontend/switch_role.php
@@ -4,7 +4,10 @@ if (!isset($_SESSION['user_id'])) {
     header('Location: signin.php');
     exit;
 }
-if (($_SESSION['role'] ?? '') !== 'admin' && empty($_SESSION['is_dev'])) {
+if (!isset($_SESSION['original_role'])) {
+    $_SESSION['original_role'] = $_SESSION['role'] ?? '';
+}
+if (($_SESSION['original_role'] ?? '') !== 'admin' && empty($_SESSION['is_dev'])) {
     header('Location: index.php');
     exit;
 }


### PR DESCRIPTION
## Summary
- Track a user's original role at sign-in and use it when switching roles.
- Preserve access to the role selector by checking the original role in the navbar and switch logic.

## Testing
- `php -l frontend/signin.php`
- `php -l frontend/switch_role.php`
- `php -l frontend/includes/navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0b76500248329b2d7bf4645ff84e1