### PR TITLE
Add finish and system selections and track part usage

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -79,7 +79,8 @@ CREATE TABLE IF NOT EXISTS door_parts (
     ly NUMERIC,
     lz NUMERIC,
     function VARCHAR(50) NOT NULL,
-    category VARCHAR(50) NOT NULL DEFAULT 'door'
+    category VARCHAR(50) NOT NULL DEFAULT 'door',
+    usage VARCHAR(50)
 );
 
 CREATE TABLE IF NOT EXISTS door_part_functions (
@@ -103,6 +104,8 @@ CREATE TABLE IF NOT EXISTS door_part_presets (
     top_rail_id INTEGER REFERENCES door_parts(id),
     bottom_rail_id INTEGER REFERENCES door_parts(id)
 );
+
+ALTER TABLE door_parts ADD COLUMN IF NOT EXISTS usage VARCHAR(50);
 
 CREATE TABLE IF NOT EXISTS door_configurations (
     id SERIAL PRIMARY KEY,

--- a/frontend/add_part.php
+++ b/frontend/add_part.php
@@ -39,6 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $lx = $ly = $lz = null;
     $function = null;
     $functions_selected = [];
+    $usage = $_POST['usage'] ?? null;
 
     switch ($category) {
         case 'frame':
@@ -67,7 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (!empty($_POST['id'])) {
         $part_id = $_POST['id'];
-        $stmt = $pdo->prepare('UPDATE door_parts SET manufacturer = ?, system = ?, part_number = ?, lx = ?, ly = ?, lz = ?, function = ?, category = ? WHERE id = ?');
+        $stmt = $pdo->prepare('UPDATE door_parts SET manufacturer = ?, system = ?, part_number = ?, lx = ?, ly = ?, lz = ?, function = ?, category = ?, usage = ? WHERE id = ?');
         $stmt->execute([
             $_POST['manufacturer'],
             $_POST['system'],
@@ -77,12 +78,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $lz,
             $function,
             $category,
+            $usage,
             $part_id
         ]);
         $pdo->prepare('DELETE FROM door_part_functions WHERE part_id = ?')->execute([$part_id]);
         $pdo->prepare('DELETE FROM door_part_requirements WHERE part_id = ?')->execute([$part_id]);
     } else {
-        $stmt = $pdo->prepare('INSERT INTO door_parts (manufacturer, system, part_number, lx, ly, lz, function, category) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+        $stmt = $pdo->prepare('INSERT INTO door_parts (manufacturer, system, part_number, lx, ly, lz, function, category, usage) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
         $stmt->execute([
             $_POST['manufacturer'],
             $_POST['system'],
@@ -91,7 +93,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $ly,
             $lz,
             $function,
-            $category
+            $category,
+            $usage
         ]);
         $part_id = $pdo->lastInsertId();
     }
@@ -227,6 +230,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                                 if (fSelect && currentFunctions[0]) {
                                                     fSelect.value = currentFunctions[0];
                                                 }
+                                                var uSelect = document.querySelector('select[name="usage"]');
+                                                if (uSelect && currentUsage) {
+                                                    uSelect.value = currentUsage;
+                                                }
                                             }
                                         }
                                     });
@@ -264,6 +271,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             var currentLy = <?php echo json_encode($part_data['ly'] ?? ''); ?>;
                             var currentLz = <?php echo json_encode($part_data['lz'] ?? ''); ?>;
                             var currentFunctions = <?php echo json_encode($existing_functions); ?>;
+                            var currentUsage = <?php echo json_encode($part_data['usage'] ?? ''); ?>;
                             loadSystems();
                             loadCategoryFields();
                         </script>

--- a/frontend/door_configurator.php
+++ b/frontend/door_configurator.php
@@ -80,6 +80,8 @@ $top_parts = $pdo->query("SELECT DISTINCT dp.id, dp.manufacturer, dp.system, dp.
 $bottom_parts = $pdo->query("SELECT DISTINCT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.lz FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'bottom_rail' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $part_presets = $pdo->query("SELECT id, name, hinge_rail_id, lock_rail_id, top_rail_id, bottom_rail_id FROM door_part_presets ORDER BY name")->fetchAll();
 
+$systems = $pdo->query("SELECT m.name AS manufacturer, s.name AS system FROM systems s JOIN manufacturers m ON s.manufacturer_id = m.id ORDER BY m.name, s.name")->fetchAll();
+
 $hinge_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'hinge_jamb' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $lock_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'lock_jamb' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $rh_hinge_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'rh_hinge_jamb' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
@@ -214,6 +216,14 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         </select>
                                     </div>
                                     <div class='mb-3'>
+                                        <label class='form-label'>Finish</label>
+                                        <select class='form-select' name='door_finish'>
+                                            <option value='c2' <?php if (($config['door_finish'] ?? '')==='c2') echo 'selected'; ?>>C2</option>
+                                            <option value='db' <?php if (($config['door_finish'] ?? '')==='db') echo 'selected'; ?>>DB</option>
+                                            <option value='bl' <?php if (($config['door_finish'] ?? '')==='bl') echo 'selected'; ?>>BL</option>
+                                        </select>
+                                    </div>
+                                    <div class='mb-3'>
                                         <label class='form-label'>Hinge Rail</label>
                                         <select class='form-select' name='hinge_rail'>
                                             <option value=''>Select Hinge Rail</option>
@@ -292,7 +302,12 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                 <div class='tab-pane fade' id='frame' role='tabpanel'>
                                     <div class='mb-3'>
                                         <label class='form-label'>System</label>
-                                        <input type='text' class='form-control' name='frame_system'>
+                                        <select class='form-select' name='frame_system'>
+                                            <option value=''>Select System</option>
+                                            <?php foreach ($systems as $sys): ?>
+                                                <option value='<?php echo htmlspecialchars($sys['system']); ?>' <?php if (($config['frame_system'] ?? '') == $sys['system']) echo 'selected'; ?>><?php echo htmlspecialchars($sys['manufacturer'] . ' ' . $sys['system']); ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
                                     </div>
                                     <div class='mb-3'>
                                         <label class='form-label'>Finish</label>

--- a/frontend/includes/parts/frame_fields.php
+++ b/frontend/includes/parts/frame_fields.php
@@ -18,6 +18,17 @@
     </select>
 </div>
 <div class='mb-3'>
+    <label class='form-label'>Usage</label>
+    <select class='form-select' name='usage'>
+        <option value=''>Select Usage</option>
+        <option value='door_jamb'>Door Jamb</option>
+        <option value='door_stop'>Door Stop</option>
+        <option value='door_header'>Door Header</option>
+        <option value='transom_gutter'>Transom Gutter</option>
+        <option value='transom_stop'>Transom Stop</option>
+    </select>
+    </div>
+<div class='mb-3'>
     <label class='form-label'>LX</label>
     <input type='number' step='any' class='form-control' name='lx'>
 </div>


### PR DESCRIPTION
## Summary
- add finish dropdown to door parts tab in configurator
- populate frame system choices from manufacturer systems
- record part usage when adding frame components

## Testing
- `php -l frontend/add_part.php`
- `php -l frontend/door_configurator.php`
- `php -l frontend/includes/parts/frame_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb79cef81483299c081ffb05b222fa