### PR TITLE
Add DaisyUI theme selector

### DIFF
--- a/frontend/includes/header.php
+++ b/frontend/includes/header.php
@@ -28,6 +28,9 @@
 
     <!-- Template Stylesheet -->
     <link href="css/style.css" rel="stylesheet">
+
+    <!-- DaisyUI Stylesheet -->
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.11.1/dist/full.min.css" rel="stylesheet" />
 </head>
 <?php $theme = $_SESSION['theme'] ?? 'light'; ?>
 <body data-theme="<?php echo htmlspecialchars($theme); ?>">

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -204,17 +204,17 @@
 
     // Theme toggler
     document.addEventListener('DOMContentLoaded', function () {
-        var toggle = document.getElementById('darkMode');
+        var select = document.getElementById('theme-select');
         var stored = localStorage.getItem('theme');
         if (stored) {
             document.body.setAttribute('data-theme', stored);
-            if (toggle) toggle.checked = stored === 'dark';
+            if (select) select.value = stored;
         } else {
             localStorage.setItem('theme', document.body.getAttribute('data-theme'));
         }
-        if (toggle) {
-            toggle.addEventListener('change', function () {
-                var theme = this.checked ? 'dark' : 'light';
+        if (select) {
+            select.addEventListener('change', function () {
+                var theme = this.value;
                 document.body.setAttribute('data-theme', theme);
                 localStorage.setItem('theme', theme);
             });

--- a/frontend/settings.php
+++ b/frontend/settings.php
@@ -5,9 +5,13 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 require_once 'includes/db.php';
+$themes = ['light', 'dark', 'cupcake', 'night', 'forest'];
 $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $theme = ($_POST['theme'] ?? 'light') === 'dark' ? 'dark' : 'light';
+    $theme = $_POST['theme'] ?? 'light';
+    if (!in_array($theme, $themes, true)) {
+        $theme = 'light';
+    }
     $stmt = $pdo->prepare('UPDATE users SET theme = ? WHERE id = ?');
     $stmt->execute([$theme, $_SESSION['user_id']]);
     $_SESSION['theme'] = $theme;
@@ -30,13 +34,17 @@ $currentTheme = $_SESSION['theme'] ?? 'light';
                             <?php if ($message): ?>
                             <div class="alert alert-success" role="alert"><?php echo $message; ?></div>
                             <?php endif; ?>
-                            <form method="post">
-                                <div class="form-check form-switch">
-                                    <input class="form-check-input" type="checkbox" id="darkMode" name="theme" value="dark" <?php if ($currentTheme === 'dark') echo 'checked'; ?>>
-                                    <label class="form-check-label" for="darkMode">Enable Dark Mode</label>
-                                </div>
-                                <button type="submit" class="btn btn-primary mt-3">Save</button>
-                            </form>
+                              <form method="post">
+                                  <div class="mb-3">
+                                      <label for="theme-select" class="form-label">Select Theme</label>
+                                      <select id="theme-select" name="theme" class="form-select">
+                                          <?php foreach ($themes as $t): ?>
+                                              <option value="<?php echo htmlspecialchars($t); ?>" <?php if ($currentTheme === $t) echo 'selected'; ?>><?php echo htmlspecialchars(ucfirst($t)); ?></option>
+                                          <?php endforeach; ?>
+                                      </select>
+                                  </div>
+                                  <button type="submit" class="btn btn-primary mt-3">Save</button>
+                              </form>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- load DaisyUI CSS and keep data-theme attribute
- replace dark mode toggle with DaisyUI theme selector and persist selection
- handle theme selection in JS with localStorage

## Testing
- `php -l frontend/includes/header.php`
- `php -l frontend/settings.php`
- `node --check frontend/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb96795854832980202091c1a98582