### PR TITLE
Add dark mode stylesheet and restore toggle

### DIFF
--- a/frontend/css/dark.css
+++ b/frontend/css/dark.css
@@ -1,0 +1,16 @@
+/* Dark mode overrides */
+body[data-theme='dark'] {
+    --primary: #009CFF;
+    --light: #191C24;
+    --dark: #F3F6F9;
+    background-color: var(--light);
+    color: var(--dark);
+}
+
+body[data-theme='dark'] .bg-light {
+    background-color: var(--light) !important;
+}
+
+body[data-theme='dark'] .text-dark {
+    color: var(--dark) !important;
+}

--- a/frontend/includes/header.php
+++ b/frontend/includes/header.php
@@ -28,6 +28,9 @@
 
     <!-- Template Stylesheet -->
     <link href="css/style.css" rel="stylesheet">
+
+    <!-- Dark Mode Stylesheet -->
+    <link href="css/dark.css" rel="stylesheet">
 </head>
 <?php $theme = $_SESSION['theme'] ?? 'light'; ?>
 <body data-theme="<?php echo htmlspecialchars($theme); ?>">


### PR DESCRIPTION
## Summary
- remove DaisyUI and load dedicated dark.css
- revert settings and JS to light/dark checkbox toggle
- persist theme in localStorage and session

## Testing
- `php -l frontend/includes/header.php`
- `php -l frontend/settings.php`
- `node --check frontend/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb96795854832980202091c1a98582