### PR TITLE
Add system default parts and multi-function frame support

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -108,6 +108,15 @@ CREATE TABLE IF NOT EXISTS door_part_presets (
 
 ALTER TABLE door_parts ADD COLUMN IF NOT EXISTS usage VARCHAR(50);
 
+CREATE TABLE IF NOT EXISTS system_default_parts (
+    id SERIAL PRIMARY KEY,
+    system_id INTEGER REFERENCES systems(id) ON DELETE CASCADE,
+    glazing_thickness VARCHAR(10) NOT NULL,
+    function VARCHAR(50) NOT NULL,
+    part_id INTEGER REFERENCES door_parts(id) ON DELETE SET NULL,
+    UNIQUE (system_id, glazing_thickness, function)
+);
+
 CREATE TABLE IF NOT EXISTS door_configurations (
     id SERIAL PRIMARY KEY,
     work_order_id INTEGER REFERENCES work_orders(id),

--- a/frontend/add_part.php
+++ b/frontend/add_part.php
@@ -46,8 +46,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $lx = $_POST['lx'] !== '' ? $_POST['lx'] : null;
             $ly = $_POST['ly'] !== '' ? $_POST['ly'] : null;
             $lz = $_POST['lz'] !== '' ? $_POST['lz'] : null;
-            $function = $_POST['frame_function'] ?? 'frame';
-            $functions_selected = [$function];
+            $functions_selected = isset($_POST['frame_functions']) ? $_POST['frame_functions'] : [];
+            $function = $functions_selected[0] ?? 'frame';
             break;
         case 'fastener':
             $lx = $_POST['length'] !== '' ? $_POST['length'] : null;
@@ -226,9 +226,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                                 });
                                             }
                                             if (category === 'frame') {
-                                                var fSelect = document.querySelector('select[name="frame_function"]');
-                                                if (fSelect && currentFunctions[0]) {
-                                                    fSelect.value = currentFunctions[0];
+                                                var fSelect = document.querySelector('select[name="frame_functions[]"]');
+                                                if (fSelect) {
+                                                    currentFunctions.forEach(function(f) {
+                                                        var option = Array.from(fSelect.options).find(o => o.value === f);
+                                                        if (option) option.selected = true;
+                                                    });
                                                 }
                                                 var uSelect = document.querySelector('select[name="usage"]');
                                                 if (uSelect && currentUsage) {

--- a/frontend/get_system_default_parts.php
+++ b/frontend/get_system_default_parts.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(403);
+    exit;
+}
+include 'includes/db.php';
+
+$manufacturer = $_GET['manufacturer'] ?? '';
+$system = $_GET['system'] ?? '';
+if ($manufacturer === '' || $system === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'manufacturer and system required']);
+    exit;
+}
+
+header('Content-Type: application/json');
+
+$stmt = $pdo->prepare(
+    "SELECT sdp.glazing_thickness, sdp.function, dp.part_number, dp.manufacturer, dp.system
+     FROM system_default_parts sdp
+     JOIN systems s ON sdp.system_id = s.id
+     JOIN manufacturers m ON s.manufacturer_id = m.id
+     LEFT JOIN door_parts dp ON sdp.part_id = dp.id
+     WHERE s.name = ? AND m.name = ?
+     ORDER BY sdp.glazing_thickness, sdp.function"
+);
+$stmt->execute([$system, $manufacturer]);
+
+$results = [];
+foreach ($stmt as $row) {
+    $thickness = $row['glazing_thickness'];
+    if (!isset($results[$thickness])) {
+        $results[$thickness] = [];
+    }
+    $results[$thickness][] = [
+        'function' => $row['function'],
+        'part_number' => $row['part_number'],
+        'manufacturer' => $row['manufacturer'],
+        'system' => $row['system'],
+    ];
+}
+
+echo json_encode($results);
+?>
+

--- a/frontend/includes/parts/frame_fields.php
+++ b/frontend/includes/parts/frame_fields.php
@@ -1,7 +1,6 @@
 <div class='mb-3'>
-    <label class='form-label'>Function</label>
-    <select class='form-select' name='frame_function' required>
-        <option value=''>Select Function</option>
+    <label class='form-label'>Functions</label>
+    <select class='form-select' name='frame_functions[]' multiple required>
         <option value='hinge_jamb'>Hinge Jamb</option>
         <option value='lock_jamb'>Lock Jamb</option>
         <option value='rh_hinge_jamb'>RH Hinge Jamb</option>
@@ -14,6 +13,8 @@
         <option value='horizontal_transom_gutter'>Horizontal Transom Gutter</option>
         <option value='horizontal_transom_stop'>Horizontal Transom Stop</option>
         <option value='vertical_transom_gutter'>Vertical Transom Gutter</option>
+        <option value='vertical_transom_stop'>Vertical Transom Stop</option>
+        <option value='head_transom_stop'>Head Transom Stop</option>
         <option value='transom_head_perimeter_filler'>Transom Head Perimeter Filler</option>
     </select>
 </div>


### PR DESCRIPTION
## Summary
- allow selecting multiple functions for frame parts including new transom stop options
- add `system_default_parts` table for default parts by system and glazing thickness
- expose `get_system_default_parts.php` API to list defaults

## Testing
- `php -l frontend/includes/parts/frame_fields.php`
- `php -l frontend/add_part.php`
- `php -l frontend/get_system_default_parts.php`
- `psql -f db/init.sql` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9fb6b4a88329a0fa9e67cc609abb