### PR TITLE
Simplify frame part functions

### DIFF
--- a/frontend/add_part.php
+++ b/frontend/add_part.php
@@ -43,7 +43,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $lx = $ly = $lz = null;
     $function = null;
     $functions_selected = [];
-    $usage = $_POST['usage'] ?? null;
     $systems = isset($_POST['systems']) ? $_POST['systems'] : [];
     $primary_system = $systems[0] ?? null;
 
@@ -74,7 +73,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (!empty($_POST['id'])) {
         $part_id = $_POST['id'];
-        $stmt = $pdo->prepare('UPDATE door_parts SET manufacturer = ?, system = ?, part_number = ?, lx = ?, ly = ?, lz = ?, function = ?, category = ?, usage = ? WHERE id = ?');
+        $stmt = $pdo->prepare('UPDATE door_parts SET manufacturer = ?, system = ?, part_number = ?, lx = ?, ly = ?, lz = ?, function = ?, category = ?, usage = NULL WHERE id = ?');
         $stmt->execute([
             $_POST['manufacturer'],
             $primary_system,
@@ -84,14 +83,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $lz,
             $function,
             $category,
-            $usage,
             $part_id
         ]);
         $pdo->prepare('DELETE FROM door_part_functions WHERE part_id = ?')->execute([$part_id]);
         $pdo->prepare('DELETE FROM door_part_requirements WHERE part_id = ?')->execute([$part_id]);
         $pdo->prepare('DELETE FROM door_part_systems WHERE part_id = ?')->execute([$part_id]);
     } else {
-        $stmt = $pdo->prepare('INSERT INTO door_parts (manufacturer, system, part_number, lx, ly, lz, function, category, usage) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+        $stmt = $pdo->prepare('INSERT INTO door_parts (manufacturer, system, part_number, lx, ly, lz, function, category, usage) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)');
         $stmt->execute([
             $_POST['manufacturer'],
             $primary_system,
@@ -100,8 +98,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $ly,
             $lz,
             $function,
-            $category,
-            $usage
+            $category
         ]);
         $part_id = $pdo->lastInsertId();
     }
@@ -249,10 +246,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                                         if (option) option.selected = true;
                                                     });
                                                 }
-                                                var uSelect = document.querySelector('select[name="usage"]');
-                                                if (uSelect && currentUsage) {
-                                                    uSelect.value = currentUsage;
-                                                }
                                             }
                                         }
                                     });
@@ -293,7 +286,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             var currentLy = <?php echo json_encode($part_data['ly'] ?? ''); ?>;
                             var currentLz = <?php echo json_encode($part_data['lz'] ?? ''); ?>;
                             var currentFunctions = <?php echo json_encode($existing_functions); ?>;
-                            var currentUsage = <?php echo json_encode($part_data['usage'] ?? ''); ?>;
                             loadSystems();
                             loadCategoryFields();
                         </script>

--- a/frontend/door_configurator.php
+++ b/frontend/door_configurator.php
@@ -84,13 +84,10 @@ $systems = $pdo->query("SELECT m.name AS manufacturer, s.name AS system FROM sys
 
 $hinge_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'hinge_jamb' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $lock_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'lock_jamb' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
-$rh_hinge_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'rh_hinge_jamb' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
-$lh_hinge_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'lh_hinge_jamb' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $door_header_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'door_header' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $transom_header_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'transom_header' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $hinge_door_stop_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'hinge_door_stop' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $latch_door_stop_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'latch_door_stop' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
-$head_door_stop_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'head_door_stop' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $horizontal_transom_gutter_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'horizontal_transom_gutter' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $horizontal_transom_stop_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'horizontal_transom_stop' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $vertical_transom_gutter_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'vertical_transom_gutter' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
@@ -341,7 +338,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <label class='form-label'>RH Hinge Jamb</label>
                                         <select class='form-select frame-part-select' name='rh_hinge_jamb'>
                                             <option value=''>Select RH Hinge Jamb</option>
-                                            <?php foreach ($rh_hinge_jamb_parts as $part): ?>
+                                            <?php foreach ($hinge_jamb_parts as $part): ?>
                                                 <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
@@ -350,7 +347,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <label class='form-label'>LH Hinge Jamb</label>
                                         <select class='form-select frame-part-select' name='lh_hinge_jamb'>
                                             <option value=''>Select LH Hinge Jamb</option>
-                                            <?php foreach ($lh_hinge_jamb_parts as $part): ?>
+                                            <?php foreach ($hinge_jamb_parts as $part): ?>
                                                 <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
@@ -387,15 +384,6 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='latch_door_stop'>
                                             <option value=''>Select Latch Door Stop</option>
                                             <?php foreach ($latch_door_stop_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
-                                            <?php endforeach; ?>
-                                        </select>
-                                    </div>
-                                    <div class='mb-3'>
-                                        <label class='form-label'>Head Door Stop</label>
-                                        <select class='form-select frame-part-select' name='head_door_stop'>
-                                            <option value=''>Select Head Door Stop</option>
-                                            <?php foreach ($head_door_stop_parts as $part): ?>
                                                 <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
@@ -767,8 +755,6 @@ cutlistTab.addEventListener('shown.bs.tab', function(){
     var lockStopLy = parseFloat(lockStopSel && lockStopSel.selectedOptions.length ? lockStopSel.selectedOptions[0].dataset.ly || 0 : 0) || 0;
     addIf(hingeStopSel, 'Hinge Jamb Stop', jambStopLength);
     addIf(lockStopSel, 'Lock Jamb Stop', jambStopLength);
-    var headStopLen = width - lockStopLy - hingeStopLy;
-    addIf(document.querySelector("select[name='head_door_stop']"), 'Head Door Stop', headStopLen);
     if(hasTransom){
         var horizStopSel = document.querySelector("select[name='horizontal_transom_stop']");
         var horizGutterSel = document.querySelector("select[name='horizontal_transom_gutter']");

--- a/frontend/door_configurator.php
+++ b/frontend/door_configurator.php
@@ -84,7 +84,7 @@ $systems = $pdo->query("SELECT m.name AS manufacturer, s.name AS system FROM sys
 
 $hinge_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'hinge_jamb' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $lock_jamb_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'lock_jamb' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
-$door_header_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'door_header' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
+$door_header_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly, dp.lz FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'door_header' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $transom_header_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'transom_header' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $hinge_door_stop_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'hinge_door_stop' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
 $latch_door_stop_parts = $pdo->query("SELECT dp.id, dp.manufacturer, dp.system, dp.part_number, dp.ly FROM door_parts dp JOIN door_part_functions dpf ON dp.id = dpf.part_id WHERE dpf.function = 'latch_door_stop' AND dp.category = 'frame' ORDER BY dp.manufacturer, dp.system, dp.part_number")->fetchAll();
@@ -357,7 +357,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='door_header'>
                                             <option value=''>Select Door Header</option>
                                             <?php foreach ($door_header_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-lz='<?php echo htmlspecialchars($part['lz']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -371,18 +371,18 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         </select>
                                     </div>
                                     <div class='mb-3'>
-                                        <label class='form-label'>Hinge Door Stop</label>
+                                        <label class='form-label' id='hinge_stop_label'>Hinge Door Stop</label>
                                         <select class='form-select frame-part-select' name='hinge_door_stop'>
-                                            <option value=''>Select Hinge Door Stop</option>
+                                            <option value='' id='hinge_stop_option'>Select Hinge Door Stop</option>
                                             <?php foreach ($hinge_door_stop_parts as $part): ?>
                                                 <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
                                     <div class='mb-3'>
-                                        <label class='form-label'>Latch Door Stop</label>
+                                        <label class='form-label' id='latch_stop_label'>Latch Door Stop</label>
                                         <select class='form-select frame-part-select' name='latch_door_stop'>
-                                            <option value=''>Select Latch Door Stop</option>
+                                            <option value='' id='latch_stop_option'>Select Latch Door Stop</option>
                                             <?php foreach ($latch_door_stop_parts as $part): ?>
                                                 <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
@@ -555,6 +555,10 @@ document.getElementById('job_select').addEventListener('change', function() {
 });
 
 var handingSelect = document.getElementById('handing');
+var hingeStopLabelEl = document.getElementById('hinge_stop_label');
+var latchStopLabelEl = document.getElementById('latch_stop_label');
+var hingeStopOptionEl = document.getElementById('hinge_stop_option');
+var latchStopOptionEl = document.getElementById('latch_stop_option');
 function updateHanding() {
     var isPair = handingSelect.value.startsWith('pair');
     document.getElementById('second_leaf').style.display = isPair ? 'block' : 'none';
@@ -564,6 +568,17 @@ function updateHanding() {
     document.querySelectorAll('.pair-only').forEach(function(el){
         el.style.display = isPair ? '' : 'none';
     });
+    if (isPair) {
+        hingeStopLabelEl.textContent = 'RH Hinge Stop';
+        hingeStopOptionEl.textContent = 'Select RH Hinge Stop';
+        latchStopLabelEl.textContent = 'LH Hinge Stop';
+        latchStopOptionEl.textContent = 'Select LH Hinge Stop';
+    } else {
+        hingeStopLabelEl.textContent = 'Hinge Door Stop';
+        hingeStopOptionEl.textContent = 'Select Hinge Door Stop';
+        latchStopLabelEl.textContent = 'Latch Door Stop';
+        latchStopOptionEl.textContent = 'Select Latch Door Stop';
+    }
 }
 handingSelect.addEventListener('change', updateHanding);
 
@@ -699,6 +714,7 @@ var cutlistTab = document.getElementById('cutlist-tab');
 cutlistTab.addEventListener('shown.bs.tab', function(){
     var width = parseFloat(document.querySelector("input[name='opening_width']").value) || 0;
     var height = parseFloat(document.querySelector("input[name='opening_height']").value) || 0;
+    var isPair = document.getElementById('handing').value.startsWith('pair');
     var topGap = parseFloat(document.getElementById('top_gap').value) || 0;
     var bottomGap = parseFloat(document.getElementById('bottom_gap').value) || 0;
     var hingeGap = parseFloat(document.getElementById('hinge_gap').value) || 0;
@@ -737,7 +753,8 @@ cutlistTab.addEventListener('shown.bs.tab', function(){
 
     var doorHeadSelect = document.querySelector("select[name='door_header']");
     var doorHeadLy = parseFloat(doorHeadSelect && doorHeadSelect.selectedOptions.length ? doorHeadSelect.selectedOptions[0].dataset.ly || 0 : 0) || 0;
-    var jambLength = hasTransom ? frameHeight : (height + doorHeadLy);
+    var doorHeadLz = parseFloat(doorHeadSelect && doorHeadSelect.selectedOptions.length ? doorHeadSelect.selectedOptions[0].dataset.lz || 0 : 0) || 0;
+    var jambLength = hasTransom ? frameHeight : (height + doorHeadLz);
     function addIf(sel, label, len){
         if(sel && sel.value && !isNaN(len)){
             body.innerHTML += '<tr><td>' + label + '</td><td>' + len.toFixed(3) + '</td></tr>';
@@ -751,10 +768,10 @@ cutlistTab.addEventListener('shown.bs.tab', function(){
     var jambStopLength = height;
     var hingeStopSel = document.querySelector("select[name='hinge_door_stop']");
     var lockStopSel = document.querySelector("select[name='latch_door_stop']");
-    var hingeStopLy = parseFloat(hingeStopSel && hingeStopSel.selectedOptions.length ? hingeStopSel.selectedOptions[0].dataset.ly || 0 : 0) || 0;
-    var lockStopLy = parseFloat(lockStopSel && lockStopSel.selectedOptions.length ? lockStopSel.selectedOptions[0].dataset.ly || 0 : 0) || 0;
-    addIf(hingeStopSel, 'Hinge Jamb Stop', jambStopLength);
-    addIf(lockStopSel, 'Lock Jamb Stop', jambStopLength);
+    var hingeStopLabel = isPair ? 'RH Hinge Stop' : 'Hinge Door Stop';
+    var lockStopLabel = isPair ? 'LH Hinge Stop' : 'Latch Door Stop';
+    addIf(hingeStopSel, hingeStopLabel, jambStopLength);
+    addIf(lockStopSel, lockStopLabel, jambStopLength);
     if(hasTransom){
         var horizStopSel = document.querySelector("select[name='horizontal_transom_stop']");
         var horizGutterSel = document.querySelector("select[name='horizontal_transom_gutter']");

--- a/frontend/door_configurator.php
+++ b/frontend/door_configurator.php
@@ -18,7 +18,7 @@ if ($config_id) {
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $config_id = $_POST['id'] ?? null;
     if ($config_id) {
-        $stmt = $pdo->prepare('UPDATE door_configurations SET name=?, has_transom=?, opening_width=?, opening_height=?, frame_height=?, glazing_thickness=?, hinge_rail_id=?, lock_rail_id=?, top_rail_id=?, bottom_rail_id=?, top_gap=?, bottom_gap=?, hinge_gap=?, latch_gap=?, handing=?, hinge_rail_2_id=?, lock_rail_2_id=?, top_rail_2_id=?, bottom_rail_2_id=? WHERE id=?');
+        $stmt = $pdo->prepare('UPDATE door_configurations SET name=?, has_transom=?, opening_width=?, opening_height=?, frame_height=?, glazing_thickness=?, hinge_rail_id=?, lock_rail_id=?, top_rail_id=?, bottom_rail_id=?, top_gap=?, bottom_gap=?, hinge_gap=?, latch_gap=?, handing=?, hinge_rail_2_id=?, lock_rail_2_id=?, top_rail_2_id=?, bottom_rail_2_id=?, frame_system=?, frame_finish=?, hinge_jamb_id=?, lock_jamb_id=?, rh_hinge_jamb_id=?, lh_hinge_jamb_id=?, door_header_id=?, transom_header_id=?, hinge_door_stop_id=?, latch_door_stop_id=?, horizontal_transom_gutter_id=?, horizontal_transom_stop_id=?, vertical_transom_gutter_id=?, vertical_transom_stop_id=?, head_transom_stop_id=?, transom_head_perimeter_filler_id=? WHERE id=?');
         $stmt->execute([
             $_POST['name'],
             isset($_POST['has_transom']) ? 1 : 0,
@@ -39,13 +39,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_POST['lock_rail_2'] !== '' ? $_POST['lock_rail_2'] : null,
             $_POST['top_rail_2'] !== '' ? $_POST['top_rail_2'] : null,
             $_POST['bottom_rail_2'] !== '' ? $_POST['bottom_rail_2'] : null,
+            $_POST['frame_system'] !== '' ? $_POST['frame_system'] : null,
+            $_POST['frame_finish'] !== '' ? $_POST['frame_finish'] : null,
+            $_POST['hinge_jamb'] !== '' ? $_POST['hinge_jamb'] : null,
+            $_POST['lock_jamb'] !== '' ? $_POST['lock_jamb'] : null,
+            $_POST['rh_hinge_jamb'] !== '' ? $_POST['rh_hinge_jamb'] : null,
+            $_POST['lh_hinge_jamb'] !== '' ? $_POST['lh_hinge_jamb'] : null,
+            $_POST['door_header'] !== '' ? $_POST['door_header'] : null,
+            $_POST['transom_header'] !== '' ? $_POST['transom_header'] : null,
+            $_POST['hinge_door_stop'] !== '' ? $_POST['hinge_door_stop'] : null,
+            $_POST['latch_door_stop'] !== '' ? $_POST['latch_door_stop'] : null,
+            $_POST['horizontal_transom_gutter'] !== '' ? $_POST['horizontal_transom_gutter'] : null,
+            $_POST['horizontal_transom_stop'] !== '' ? $_POST['horizontal_transom_stop'] : null,
+            $_POST['vertical_transom_gutter'] !== '' ? $_POST['vertical_transom_gutter'] : null,
+            $_POST['vertical_transom_stop'] !== '' ? $_POST['vertical_transom_stop'] : null,
+            $_POST['head_transom_stop'] !== '' ? $_POST['head_transom_stop'] : null,
+            $_POST['transom_head_perimeter_filler'] !== '' ? $_POST['transom_head_perimeter_filler'] : null,
             $config_id
         ]);
         $cfg_stmt = $pdo->prepare("SELECT dc.*, wo.job_id, jobs.job_name, wo.work_order_number FROM door_configurations dc JOIN work_orders wo ON dc.work_order_id = wo.id JOIN jobs ON wo.job_id = jobs.id WHERE dc.id=?");
         $cfg_stmt->execute([$config_id]);
         $config = $cfg_stmt->fetch();
     } else {
-        $stmt = $pdo->prepare('INSERT INTO door_configurations (work_order_id, name, has_transom, opening_width, opening_height, frame_height, glazing_thickness, hinge_rail_id, lock_rail_id, top_rail_id, bottom_rail_id, top_gap, bottom_gap, hinge_gap, latch_gap, handing, hinge_rail_2_id, lock_rail_2_id, top_rail_2_id, bottom_rail_2_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) RETURNING id');
+        $stmt = $pdo->prepare('INSERT INTO door_configurations (work_order_id, name, has_transom, opening_width, opening_height, frame_height, glazing_thickness, hinge_rail_id, lock_rail_id, top_rail_id, bottom_rail_id, top_gap, bottom_gap, hinge_gap, latch_gap, handing, hinge_rail_2_id, lock_rail_2_id, top_rail_2_id, bottom_rail_2_id, frame_system, frame_finish, hinge_jamb_id, lock_jamb_id, rh_hinge_jamb_id, lh_hinge_jamb_id, door_header_id, transom_header_id, hinge_door_stop_id, latch_door_stop_id, horizontal_transom_gutter_id, horizontal_transom_stop_id, vertical_transom_gutter_id, vertical_transom_stop_id, head_transom_stop_id, transom_head_perimeter_filler_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) RETURNING id');
         $stmt->execute([
             $_POST['work_order'],
             $_POST['name'],
@@ -66,7 +82,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_POST['hinge_rail_2'] !== '' ? $_POST['hinge_rail_2'] : null,
             $_POST['lock_rail_2'] !== '' ? $_POST['lock_rail_2'] : null,
             $_POST['top_rail_2'] !== '' ? $_POST['top_rail_2'] : null,
-            $_POST['bottom_rail_2'] !== '' ? $_POST['bottom_rail_2'] : null
+            $_POST['bottom_rail_2'] !== '' ? $_POST['bottom_rail_2'] : null,
+            $_POST['frame_system'] !== '' ? $_POST['frame_system'] : null,
+            $_POST['frame_finish'] !== '' ? $_POST['frame_finish'] : null,
+            $_POST['hinge_jamb'] !== '' ? $_POST['hinge_jamb'] : null,
+            $_POST['lock_jamb'] !== '' ? $_POST['lock_jamb'] : null,
+            $_POST['rh_hinge_jamb'] !== '' ? $_POST['rh_hinge_jamb'] : null,
+            $_POST['lh_hinge_jamb'] !== '' ? $_POST['lh_hinge_jamb'] : null,
+            $_POST['door_header'] !== '' ? $_POST['door_header'] : null,
+            $_POST['transom_header'] !== '' ? $_POST['transom_header'] : null,
+            $_POST['hinge_door_stop'] !== '' ? $_POST['hinge_door_stop'] : null,
+            $_POST['latch_door_stop'] !== '' ? $_POST['latch_door_stop'] : null,
+            $_POST['horizontal_transom_gutter'] !== '' ? $_POST['horizontal_transom_gutter'] : null,
+            $_POST['horizontal_transom_stop'] !== '' ? $_POST['horizontal_transom_stop'] : null,
+            $_POST['vertical_transom_gutter'] !== '' ? $_POST['vertical_transom_gutter'] : null,
+            $_POST['vertical_transom_stop'] !== '' ? $_POST['vertical_transom_stop'] : null,
+            $_POST['head_transom_stop'] !== '' ? $_POST['head_transom_stop'] : null,
+            $_POST['transom_head_perimeter_filler'] !== '' ? $_POST['transom_head_perimeter_filler'] : null
         ]);
         $config_id = $stmt->fetchColumn();
         $cfg_stmt = $pdo->prepare("SELECT dc.*, wo.job_id, jobs.job_name, wo.work_order_number FROM door_configurations dc JOIN work_orders wo ON dc.work_order_id = wo.id JOIN jobs ON wo.job_id = jobs.id WHERE dc.id=?");
@@ -311,9 +343,9 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                     <div class='mb-3'>
                                         <label class='form-label'>Finish</label>
                                         <select class='form-select' name='frame_finish'>
-                                            <option value='c2'>C2</option>
-                                            <option value='db'>DB</option>
-                                            <option value='bl'>BL</option>
+                                            <option value='c2' <?php if (($config['frame_finish'] ?? '') === 'c2') echo 'selected'; ?>>C2</option>
+                                            <option value='db' <?php if (($config['frame_finish'] ?? '') === 'db') echo 'selected'; ?>>DB</option>
+                                            <option value='bl' <?php if (($config['frame_finish'] ?? '') === 'bl') echo 'selected'; ?>>BL</option>
                                         </select>
                                     </div>
                                     <div class='mb-3 single-only'>
@@ -321,7 +353,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='hinge_jamb'>
                                             <option value=''>Select Hinge Jamb</option>
                                             <?php foreach ($hinge_jamb_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['hinge_jamb_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -330,7 +362,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='lock_jamb'>
                                             <option value=''>Select Lock Jamb</option>
                                             <?php foreach ($lock_jamb_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['lock_jamb_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -339,7 +371,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='rh_hinge_jamb'>
                                             <option value=''>Select RH Hinge Jamb</option>
                                             <?php foreach ($hinge_jamb_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['rh_hinge_jamb_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -348,7 +380,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='lh_hinge_jamb'>
                                             <option value=''>Select LH Hinge Jamb</option>
                                             <?php foreach ($hinge_jamb_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['lh_hinge_jamb_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -357,7 +389,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='door_header'>
                                             <option value=''>Select Door Header</option>
                                             <?php foreach ($door_header_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-lz='<?php echo htmlspecialchars($part['lz']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-lz='<?php echo htmlspecialchars($part['lz']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['door_header_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -365,9 +397,9 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <label class='form-label'>Transom Header</label>
                                         <select class='form-select frame-part-select' name='transom_header'>
                                             <option value=''>Select Transom Header</option>
-                                            <?php foreach ($transom_header_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
-                                            <?php endforeach; ?>
+        <?php foreach ($transom_header_parts as $part): ?>
+            <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['transom_header_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+        <?php endforeach; ?>
                                         </select>
                                     </div>
                                     <div class='mb-3'>
@@ -375,7 +407,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='hinge_door_stop'>
                                             <option value='' id='hinge_stop_option'>Select Hinge Door Stop</option>
                                             <?php foreach ($hinge_door_stop_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['hinge_door_stop_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -384,7 +416,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='latch_door_stop'>
                                             <option value='' id='latch_stop_option'>Select Latch Door Stop</option>
                                             <?php foreach ($latch_door_stop_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['latch_door_stop_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -393,7 +425,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='horizontal_transom_gutter'>
                                             <option value=''>Select Horizontal Transom Gutter</option>
                                             <?php foreach ($horizontal_transom_gutter_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['horizontal_transom_gutter_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -402,7 +434,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='horizontal_transom_stop'>
                                             <option value=''>Select Horizontal Transom Stop</option>
                                             <?php foreach ($horizontal_transom_stop_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['horizontal_transom_stop_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -411,7 +443,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='vertical_transom_gutter'>
                                             <option value=''>Select Vertical Transom Gutter</option>
                                             <?php foreach ($vertical_transom_gutter_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['vertical_transom_gutter_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -420,7 +452,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='vertical_transom_stop'>
                                             <option value=''>Select Vertical Transom Stop</option>
                                             <?php foreach ($vertical_transom_stop_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['vertical_transom_stop_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -429,7 +461,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='head_transom_stop'>
                                             <option value=''>Select Head Transom Stop</option>
                                             <?php foreach ($head_transom_stop_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-ly='<?php echo htmlspecialchars($part['ly']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['head_transom_stop_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
@@ -438,7 +470,7 @@ $transom_head_perimeter_filler_parts = $pdo->query("SELECT dp.id, dp.manufacture
                                         <select class='form-select frame-part-select' name='transom_head_perimeter_filler'>
                                             <option value=''>Select Transom Head Perimeter Filler</option>
                                             <?php foreach ($transom_head_perimeter_filler_parts as $part): ?>
-                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame'><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
+                                                <option value='<?php echo htmlspecialchars($part['id']); ?>' data-system='<?php echo htmlspecialchars($part['system']); ?>' data-part-number='<?php echo htmlspecialchars($part['part_number']); ?>' data-category='frame' <?php if (($config['transom_head_perimeter_filler_id'] ?? '') == $part['id']) echo 'selected'; ?>><?php echo htmlspecialchars($part['manufacturer'] . ' ' . $part['system'] . ' ' . $part['part_number']); ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>

--- a/frontend/includes/parts/frame_fields.php
+++ b/frontend/includes/parts/frame_fields.php
@@ -3,13 +3,10 @@
     <select class='form-select' name='frame_functions[]' multiple required>
         <option value='hinge_jamb'>Hinge Jamb</option>
         <option value='lock_jamb'>Lock Jamb</option>
-        <option value='rh_hinge_jamb'>RH Hinge Jamb</option>
-        <option value='lh_hinge_jamb'>LH Hinge Jamb</option>
         <option value='door_header'>Door Header</option>
         <option value='transom_header'>Transom Header</option>
         <option value='hinge_door_stop'>Hinge Door Stop</option>
         <option value='latch_door_stop'>Latch Door Stop</option>
-        <option value='head_door_stop'>Head Door Stop</option>
         <option value='horizontal_transom_gutter'>Horizontal Transom Gutter</option>
         <option value='horizontal_transom_stop'>Horizontal Transom Stop</option>
         <option value='vertical_transom_gutter'>Vertical Transom Gutter</option>
@@ -18,17 +15,6 @@
         <option value='transom_head_perimeter_filler'>Transom Head Perimeter Filler</option>
     </select>
 </div>
-<div class='mb-3'>
-    <label class='form-label'>Usage</label>
-    <select class='form-select' name='usage'>
-        <option value=''>Select Usage</option>
-        <option value='door_jamb'>Door Jamb</option>
-        <option value='door_stop'>Door Stop</option>
-        <option value='door_header'>Door Header</option>
-        <option value='transom_gutter'>Transom Gutter</option>
-        <option value='transom_stop'>Transom Stop</option>
-    </select>
-    </div>
 <div class='mb-3'>
     <label class='form-label'>LX</label>
     <input type='number' step='any' class='form-control' name='lx'>


### PR DESCRIPTION
## Summary
- Drop separate usage field from frame part form and keep only essential function options
- Store frame parts without usage metadata and reuse hinge jambs for both RH and LH
- Remove head door stop and orientational hinge jamb queries from door configurator

## Testing
- `php -l frontend/includes/parts/frame_fields.php`
- `php -l frontend/add_part.php`
- `php -l frontend/door_configurator.php`


------
https://chatgpt.com/codex/tasks/task_e_68be1f7b44e08329acc4d15948403730